### PR TITLE
Add REST API v1 with Bearer token authentication

### DIFF
--- a/db/migrate/002_add_api_token_to_users.rb
+++ b/db/migrate/002_add_api_token_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddApiTokenToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :api_token, :string, limit: 64
+    add_index :users, :api_token, unique: true
+  end
+end

--- a/lib/lokka/app.rb
+++ b/lib/lokka/app.rb
@@ -10,6 +10,10 @@ module Lokka
       register Sinatra::Reloader
     end
 
+    configure :development, :test do
+      set :host_authorization, { permitted_hosts: [] }
+    end
+
     configure do
       enable :method_override, :raise_errors, :static, :sessions
       register Padrino::Helpers
@@ -39,6 +43,7 @@ module Lokka
     end
 
     require 'lokka/app/admin.rb'
+    require 'lokka/app/api.rb'
     require 'lokka/app/entries.rb'
 
     not_found do

--- a/lib/lokka/app/api.rb
+++ b/lib/lokka/app/api.rb
@@ -1,0 +1,470 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Lokka
+  class App
+    # ---------------------------------------------------------------------------
+    # JSON API  –  /api/v1/*
+    #
+    # Authentication: Bearer token in Authorization header
+    #   Authorization: Bearer <user.api_token>
+    # ---------------------------------------------------------------------------
+
+    before '/api/v1/*' do
+      content_type :json
+
+      # Skip CSRF protection for API requests
+      env['rack.protection.csrf.token'] = true
+
+      # /api/v1/token uses name/password auth, not Bearer token
+      pass if request.path_info == '/api/v1/token' && request.post?
+
+      token = extract_bearer_token
+      @api_user = User.authenticate_by_token(token)
+      unless @api_user
+        halt 401, { error: 'Unauthorized', message: 'Invalid or missing API token' }.to_json
+      end
+    end
+
+    helpers do
+      def extract_bearer_token
+        auth = request.env['HTTP_AUTHORIZATION'].to_s
+        match = auth.match(/\ABearer\s+(.+)\z/i)
+        match ? match[1].strip : nil
+      end
+
+      def json_body
+        @json_body ||= begin
+          body = request.body.read
+          body.empty? ? {} : JSON.parse(body)
+        rescue JSON::ParserError
+          halt 400, { error: 'Bad Request', message: 'Invalid JSON' }.to_json
+        end
+      end
+
+      def entry_json(entry)
+        {
+          id: entry.id,
+          type: entry.type,
+          title: entry.title,
+          body: entry.raw_body,
+          slug: entry.slug,
+          markup: entry.markup,
+          draft: entry.draft,
+          category_id: entry.category_id,
+          user_id: entry.user_id,
+          tags: entry.tag_list,
+          link: entry.link,
+          created_at: entry.created_at&.iso8601,
+          updated_at: entry.updated_at&.iso8601
+        }
+      end
+
+      def category_json(category)
+        {
+          id: category.id,
+          title: category.title,
+          slug: category.slug,
+          description: category.description,
+          parent_id: category.parent_id,
+          created_at: category.created_at&.iso8601,
+          updated_at: category.updated_at&.iso8601
+        }
+      end
+
+      def tag_json(tag)
+        {
+          id: tag.id,
+          name: tag.name,
+          created_at: tag.created_at&.iso8601,
+          updated_at: tag.updated_at&.iso8601
+        }
+      end
+
+      def comment_json(comment)
+        {
+          id: comment.id,
+          entry_id: comment.entry_id,
+          status: comment.status,
+          name: comment.name,
+          email: comment.email,
+          homepage: comment.homepage,
+          body: comment.body,
+          created_at: comment.created_at&.iso8601,
+          updated_at: comment.updated_at&.iso8601
+        }
+      end
+
+      def user_json(user)
+        {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          permission_level: user.permission_level,
+          created_at: user.created_at&.iso8601,
+          updated_at: user.updated_at&.iso8601
+        }
+      end
+
+      def snippet_json(snippet)
+        {
+          id: snippet.id,
+          name: snippet.name,
+          body: snippet.body,
+          created_at: snippet.created_at&.iso8601,
+          updated_at: snippet.updated_at&.iso8601
+        }
+      end
+
+      def paginate(scope)
+        page = (params[:page] || 1).to_i
+        per  = [(params[:per_page] || 20).to_i, 100].min
+        scope.page(page).per(per)
+      end
+
+      def pagination_meta(collection)
+        {
+          current_page: collection.current_page,
+          total_pages: collection.total_pages,
+          total_count: collection.total_count,
+          per_page: collection.limit_value
+        }
+      end
+
+      def require_admin!
+        unless @api_user.admin?
+          halt 403, { error: 'Forbidden', message: 'Admin access required' }.to_json
+        end
+      end
+    end
+
+    # ---- Posts ----------------------------------------------------------------
+
+    get '/api/v1/posts' do
+      posts = params[:draft] == 'true' ? Post.unpublished : Post.published
+      posts = paginate(posts)
+      { posts: posts.map { |p| entry_json(p) }, meta: pagination_meta(posts) }.to_json
+    end
+
+    get '/api/v1/posts/:id' do |id|
+      post = Post.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      { post: entry_json(post) }.to_json
+    end
+
+    post '/api/v1/posts' do
+      attrs = json_body['post'] || {}
+      post = Post.new(attrs.slice('title', 'body', 'slug', 'markup', 'draft', 'category_id'))
+      post.user = @api_user
+
+      if post.save
+        post.tag_collection = attrs['tags'].join(',') if attrs['tags'].is_a?(Array)
+        post.tag_collection = attrs['tag_collection'] if attrs['tag_collection']
+        status 201
+        { post: entry_json(post.reload) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: post.errors.full_messages }.to_json
+      end
+    end
+
+    put '/api/v1/posts/:id' do |id|
+      post = Post.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      attrs = json_body['post'] || {}
+      post.tag_collection = attrs.delete('tags').join(',') if attrs['tags'].is_a?(Array)
+      post.tag_collection = attrs.delete('tag_collection') if attrs['tag_collection']
+
+      if post.update(attrs.slice('title', 'body', 'slug', 'markup', 'draft', 'category_id'))
+        { post: entry_json(post) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: post.errors.full_messages }.to_json
+      end
+    end
+
+    delete '/api/v1/posts/:id' do |id|
+      post = Post.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      post.destroy
+      status 204
+      ''
+    end
+
+    # ---- Pages ----------------------------------------------------------------
+
+    get '/api/v1/pages' do
+      pages = params[:draft] == 'true' ? Page.unpublished : Page.published
+      pages = paginate(pages)
+      { pages: pages.map { |p| entry_json(p) }, meta: pagination_meta(pages) }.to_json
+    end
+
+    get '/api/v1/pages/:id' do |id|
+      page = Page.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      { page: entry_json(page) }.to_json
+    end
+
+    post '/api/v1/pages' do
+      attrs = json_body['page'] || {}
+      page = Page.new(attrs.slice('title', 'body', 'slug', 'markup', 'draft', 'category_id'))
+      page.user = @api_user
+
+      if page.save
+        page.tag_collection = attrs['tags'].join(',') if attrs['tags'].is_a?(Array)
+        page.tag_collection = attrs['tag_collection'] if attrs['tag_collection']
+        status 201
+        { page: entry_json(page.reload) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: page.errors.full_messages }.to_json
+      end
+    end
+
+    put '/api/v1/pages/:id' do |id|
+      page = Page.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      attrs = json_body['page'] || {}
+      page.tag_collection = attrs.delete('tags').join(',') if attrs['tags'].is_a?(Array)
+      page.tag_collection = attrs.delete('tag_collection') if attrs['tag_collection']
+
+      if page.update(attrs.slice('title', 'body', 'slug', 'markup', 'draft', 'category_id'))
+        { page: entry_json(page) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: page.errors.full_messages }.to_json
+      end
+    end
+
+    delete '/api/v1/pages/:id' do |id|
+      page = Page.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      page.destroy
+      status 204
+      ''
+    end
+
+    # ---- Categories -----------------------------------------------------------
+
+    get '/api/v1/categories' do
+      categories = paginate(Category.order(:title))
+      { categories: categories.map { |c| category_json(c) }, meta: pagination_meta(categories) }.to_json
+    end
+
+    get '/api/v1/categories/:id' do |id|
+      category = Category.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      { category: category_json(category) }.to_json
+    end
+
+    post '/api/v1/categories' do
+      attrs = json_body['category'] || {}
+      category = Category.new(attrs.slice('title', 'slug', 'description', 'parent_id'))
+
+      if category.save
+        status 201
+        { category: category_json(category) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: category.errors.full_messages }.to_json
+      end
+    end
+
+    put '/api/v1/categories/:id' do |id|
+      category = Category.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+
+      if category.update((json_body['category'] || {}).slice('title', 'slug', 'description', 'parent_id'))
+        { category: category_json(category) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: category.errors.full_messages }.to_json
+      end
+    end
+
+    delete '/api/v1/categories/:id' do |id|
+      category = Category.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      category.destroy
+      status 204
+      ''
+    end
+
+    # ---- Tags -----------------------------------------------------------------
+
+    get '/api/v1/tags' do
+      tags = paginate(Tag.order(:name))
+      { tags: tags.map { |t| tag_json(t) }, meta: pagination_meta(tags) }.to_json
+    end
+
+    get '/api/v1/tags/:id' do |id|
+      tag = Tag.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      { tag: tag_json(tag) }.to_json
+    end
+
+    put '/api/v1/tags/:id' do |id|
+      tag = Tag.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+
+      if tag.update((json_body['tag'] || {}).slice('name'))
+        { tag: tag_json(tag) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: tag.errors.full_messages }.to_json
+      end
+    end
+
+    delete '/api/v1/tags/:id' do |id|
+      tag = Tag.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      tag.destroy
+      status 204
+      ''
+    end
+
+    # ---- Comments -------------------------------------------------------------
+
+    get '/api/v1/comments' do
+      comments = Comment.order(created_at: :desc)
+      comments = comments.where(entry_id: params[:entry_id]) if params[:entry_id]
+      comments = paginate(comments)
+      { comments: comments.map { |c| comment_json(c) }, meta: pagination_meta(comments) }.to_json
+    end
+
+    get '/api/v1/comments/:id' do |id|
+      comment = Comment.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      { comment: comment_json(comment) }.to_json
+    end
+
+    post '/api/v1/comments' do
+      attrs = json_body['comment'] || {}
+      comment = Comment.new(attrs.slice('entry_id', 'name', 'email', 'homepage', 'body', 'status'))
+
+      if comment.save
+        status 201
+        { comment: comment_json(comment) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: comment.errors.full_messages }.to_json
+      end
+    end
+
+    put '/api/v1/comments/:id' do |id|
+      comment = Comment.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+
+      if comment.update((json_body['comment'] || {}).slice('name', 'email', 'homepage', 'body', 'status'))
+        { comment: comment_json(comment) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: comment.errors.full_messages }.to_json
+      end
+    end
+
+    delete '/api/v1/comments/:id' do |id|
+      comment = Comment.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      comment.destroy
+      status 204
+      ''
+    end
+
+    # ---- Users (admin only) ---------------------------------------------------
+
+    get '/api/v1/users' do
+      require_admin!
+      users = paginate(User.order(created_at: :desc))
+      { users: users.map { |u| user_json(u) }, meta: pagination_meta(users) }.to_json
+    end
+
+    get '/api/v1/users/:id' do |id|
+      require_admin!
+      user = User.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      { user: user_json(user) }.to_json
+    end
+
+    # ---- Snippets -------------------------------------------------------------
+
+    get '/api/v1/snippets' do
+      snippets = paginate(Snippet.order(created_at: :desc))
+      { snippets: snippets.map { |s| snippet_json(s) }, meta: pagination_meta(snippets) }.to_json
+    end
+
+    get '/api/v1/snippets/:id' do |id|
+      snippet = Snippet.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      { snippet: snippet_json(snippet) }.to_json
+    end
+
+    post '/api/v1/snippets' do
+      attrs = json_body['snippet'] || {}
+      snippet = Snippet.new(attrs.slice('name', 'body'))
+
+      if snippet.save
+        status 201
+        { snippet: snippet_json(snippet) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: snippet.errors.full_messages }.to_json
+      end
+    end
+
+    put '/api/v1/snippets/:id' do |id|
+      snippet = Snippet.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+
+      if snippet.update((json_body['snippet'] || {}).slice('name', 'body'))
+        { snippet: snippet_json(snippet) }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: snippet.errors.full_messages }.to_json
+      end
+    end
+
+    delete '/api/v1/snippets/:id' do |id|
+      snippet = Snippet.find_by(id: id) || halt(404, { error: 'Not Found' }.to_json)
+      snippet.destroy
+      status 204
+      ''
+    end
+
+    # ---- Current User / Token -------------------------------------------------
+
+    get '/api/v1/me' do
+      { user: user_json(@api_user), api_token: @api_user.api_token }.to_json
+    end
+
+    post '/api/v1/token' do
+      # Authenticate with name/password, returns (or generates) an API token
+      name = json_body['name'] || json_body['username']
+      password = json_body['password']
+
+      user = User.authenticate(name, password)
+      unless user
+        halt 401, { error: 'Unauthorized', message: 'Invalid credentials' }.to_json
+      end
+
+      user.generate_api_token! if user.api_token.blank?
+
+      status 201
+      { token: user.api_token, user: user_json(user) }.to_json
+    end
+
+    # ---- Site -----------------------------------------------------------------
+
+    get '/api/v1/site' do
+      site = Site.first
+      {
+        site: {
+          title: site.title,
+          description: site.description,
+          theme: site.theme,
+          per_page: site.per_page,
+          default_markup: site.default_markup,
+          meta_description: site.meta_description,
+          meta_keywords: site.meta_keywords
+        }
+      }.to_json
+    end
+
+    put '/api/v1/site' do
+      require_admin!
+      site = Site.first
+      attrs = json_body['site'] || {}
+
+      if site.update(attrs.slice('title', 'description', 'theme', 'per_page',
+                                 'default_markup', 'meta_description', 'meta_keywords'))
+        { site: { title: site.title, description: site.description, theme: site.theme } }.to_json
+      else
+        status 422
+        { error: 'Validation Failed', messages: site.errors.full_messages }.to_json
+      end
+    end
+  end
+end

--- a/lib/lokka/models/user.rb
+++ b/lib/lokka/models/user.rb
@@ -36,6 +36,16 @@ class User < ActiveRecord::Base
     permission_level == 1
   end
 
+  def generate_api_token!
+    update!(api_token: SecureRandom.hex(32))
+    api_token
+  end
+
+  def self.authenticate_by_token(token)
+    return nil if token.blank?
+    find_by(api_token: token)
+  end
+
   def password_require?
     new_record? || !password.blank?
   end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+ENV['RACK_ENV'] = ENV['LOKKA_ENV'] = 'test'
+
+require 'bundler/setup'
+require File.expand_path('../init', __dir__)
+
+Lokka::Database.new.connect.migrate
+
+require 'minitest/autorun'
+require 'rack/test'
+
+class ApiTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    Lokka::App
+  end
+
+  def setup
+    @site = Site.create!(
+      title: 'Test Site',
+      description: 'A test site',
+      theme: 'jarvi'
+    )
+    @user = User.create!(
+      name: 'testuser',
+      email: 'test@example.com',
+      password: 'testpass',
+      password_confirmation: 'testpass',
+      permission_level: 1
+    )
+    @user.generate_api_token!
+    @token = @user.api_token
+  end
+
+  def teardown
+    Field.delete_all
+    Tagging.delete_all
+    Tag.delete_all
+    Comment.delete_all
+    Entry.delete_all
+    Snippet.delete_all
+    Category.delete_all
+    User.delete_all
+    Site.delete_all
+  end
+
+  def auth_header
+    { 'HTTP_AUTHORIZATION' => "Bearer #{@token}" }
+  end
+
+  def json_header
+    auth_header.merge('CONTENT_TYPE' => 'application/json')
+  end
+
+  def json_response
+    JSON.parse(last_response.body)
+  end
+
+  # --- Authentication ---
+
+  def test_returns_401_without_token
+    get '/api/v1/posts'
+    assert_equal 401, last_response.status
+  end
+
+  def test_returns_401_with_invalid_token
+    get '/api/v1/posts', {}, { 'HTTP_AUTHORIZATION' => 'Bearer invalid' }
+    assert_equal 401, last_response.status
+  end
+
+  # --- Token ---
+
+  def test_token_endpoint_returns_token_with_valid_credentials
+    post '/api/v1/token',
+         { name: 'testuser', password: 'testpass' }.to_json,
+         { 'CONTENT_TYPE' => 'application/json' }
+    assert_equal 201, last_response.status
+    body = json_response
+    refute_nil body['token']
+    assert_equal 'testuser', body['user']['name']
+  end
+
+  def test_token_endpoint_returns_401_with_invalid_credentials
+    post '/api/v1/token',
+         { name: 'testuser', password: 'wrong' }.to_json,
+         { 'CONTENT_TYPE' => 'application/json' }
+    assert_equal 401, last_response.status
+  end
+
+  # --- Posts ---
+
+  def test_list_posts
+    Post.create!(title: 'Hello', body: 'World', user: @user)
+    get '/api/v1/posts', {}, auth_header
+    assert_equal 200, last_response.status
+    assert_equal 1, json_response['posts'].length
+    assert json_response['meta']['total_count']
+  end
+
+  def test_create_post
+    post '/api/v1/posts',
+         { post: { title: 'API Post', body: 'Hello', markup: 'html' } }.to_json,
+         json_header
+    assert_equal 201, last_response.status
+    assert_equal 'API Post', json_response['post']['title']
+    assert_equal @user.id, json_response['post']['user_id']
+  end
+
+  def test_create_post_with_tags
+    post '/api/v1/posts',
+         { post: { title: 'Tagged', body: 'body', tags: %w[ruby sinatra] } }.to_json,
+         json_header
+    assert_equal 201, last_response.status
+    assert_includes json_response['post']['tags'], 'ruby'
+    assert_includes json_response['post']['tags'], 'sinatra'
+  end
+
+  def test_create_post_returns_422_for_invalid
+    post '/api/v1/posts',
+         { post: { body: 'no title' } }.to_json,
+         json_header
+    assert_equal 422, last_response.status
+    assert json_response['messages'].any? { |m| m =~ /title/i }
+  end
+
+  def test_show_post
+    entry = Post.create!(title: 'Show Me', body: 'body', user: @user)
+    get "/api/v1/posts/#{entry.id}", {}, auth_header
+    assert_equal 200, last_response.status
+    assert_equal entry.id, json_response['post']['id']
+  end
+
+  def test_update_post
+    entry = Post.create!(title: 'Old Title', body: 'body', user: @user)
+    put "/api/v1/posts/#{entry.id}",
+        { post: { title: 'New Title' } }.to_json,
+        json_header
+    assert_equal 200, last_response.status
+    assert_equal 'New Title', json_response['post']['title']
+  end
+
+  def test_delete_post
+    entry = Post.create!(title: 'Delete Me', body: 'body', user: @user)
+    delete "/api/v1/posts/#{entry.id}", {}, auth_header
+    assert_equal 204, last_response.status
+    assert_nil Post.find_by(id: entry.id)
+  end
+
+  def test_post_not_found
+    get '/api/v1/posts/999999', {}, auth_header
+    assert_equal 404, last_response.status
+  end
+
+  # --- Pages ---
+
+  def test_create_page
+    post '/api/v1/pages',
+         { page: { title: 'API Page', body: 'Page body' } }.to_json,
+         json_header
+    assert_equal 201, last_response.status
+    assert_equal 'Page', json_response['page']['type']
+  end
+
+  def test_list_pages
+    Page.create!(title: 'Test Page', body: 'body', user: @user)
+    get '/api/v1/pages', {}, auth_header
+    assert_equal 200, last_response.status
+    assert_equal 1, json_response['pages'].length
+  end
+
+  # --- Categories ---
+
+  def test_category_crud
+    # create
+    post '/api/v1/categories',
+         { category: { title: 'Tech', slug: 'tech' } }.to_json,
+         json_header
+    assert_equal 201, last_response.status
+    cat_id = json_response['category']['id']
+
+    # read
+    get "/api/v1/categories/#{cat_id}", {}, auth_header
+    assert_equal 200, last_response.status
+    assert_equal 'Tech', json_response['category']['title']
+
+    # update
+    put "/api/v1/categories/#{cat_id}",
+        { category: { title: 'Technology' } }.to_json,
+        json_header
+    assert_equal 200, last_response.status
+    assert_equal 'Technology', json_response['category']['title']
+
+    # delete
+    delete "/api/v1/categories/#{cat_id}", {}, auth_header
+    assert_equal 204, last_response.status
+  end
+
+  # --- Tags ---
+
+  def test_list_and_update_tags
+    tag = Tag.create!(name: 'original')
+    get '/api/v1/tags', {}, auth_header
+    assert_equal 200, last_response.status
+
+    put "/api/v1/tags/#{tag.id}",
+        { tag: { name: 'renamed' } }.to_json,
+        json_header
+    assert_equal 200, last_response.status
+    assert_equal 'renamed', json_response['tag']['name']
+  end
+
+  # --- Comments ---
+
+  def test_create_and_list_comments
+    entry = Post.create!(title: 'Commented', body: 'body', user: @user)
+    post '/api/v1/comments',
+         { comment: { entry_id: entry.id, name: 'Tester', body: 'Nice!' } }.to_json,
+         json_header
+    assert_equal 201, last_response.status
+
+    get '/api/v1/comments', { entry_id: entry.id }, auth_header
+    assert_equal 200, last_response.status
+    assert_equal 1, json_response['comments'].length
+  end
+
+  # --- Snippets ---
+
+  def test_snippet_crud
+    post '/api/v1/snippets',
+         { snippet: { name: 'header', body: '<h1>Hi</h1>' } }.to_json,
+         json_header
+    assert_equal 201, last_response.status
+    snippet_id = json_response['snippet']['id']
+
+    put "/api/v1/snippets/#{snippet_id}",
+        { snippet: { body: '<h1>Hello</h1>' } }.to_json,
+        json_header
+    assert_equal 200, last_response.status
+
+    delete "/api/v1/snippets/#{snippet_id}", {}, auth_header
+    assert_equal 204, last_response.status
+  end
+
+  # --- Users ---
+
+  def test_list_users_for_admin
+    get '/api/v1/users', {}, auth_header
+    assert_equal 200, last_response.status
+  end
+
+  # --- Site ---
+
+  def test_get_site_info
+    get '/api/v1/site', {}, auth_header
+    assert_equal 200, last_response.status
+    assert_equal 'Test Site', json_response['site']['title']
+  end
+
+  def test_update_site_info
+    put '/api/v1/site',
+        { site: { title: 'New Title' } }.to_json,
+        json_header
+    assert_equal 200, last_response.status
+  end
+
+  # --- Me ---
+
+  def test_me_endpoint
+    get '/api/v1/me', {}, auth_header
+    assert_equal 200, last_response.status
+    assert_equal 'testuser', json_response['user']['name']
+    assert_equal @token, json_response['api_token']
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds a JSON REST API to Lokka.

## Authentication

The API uses Bearer token authentication.
Clients can obtain a token via `POST /api/v1/token` with a username and password.

```bash
# Get a token
curl -X POST /api/v1/token \
  -H 'Content-Type: application/json' \
  -d '{"name":"admin","password":"xxx"}'

# Call the API
curl /api/v1/posts \
  -H 'Authorization: Bearer <token>'
```

## Endpoints

| Resource | GET | POST | PUT | DELETE |
| --- | --- | --- | --- | --- |
| `/api/v1/posts` | ✅ list/show | ✅ create | ✅ update | ✅ delete |
| `/api/v1/pages` | ✅ | ✅ | ✅ | ✅ |
| `/api/v1/categories` | ✅ | ✅ | ✅ | ✅ |
| `/api/v1/tags` | ✅ | - | ✅ | ✅ |
| `/api/v1/comments` | ✅ | ✅ | ✅ | ✅ |
| `/api/v1/snippets` | ✅ | ✅ | ✅ | ✅ |
| `/api/v1/site` | ✅ | - | ✅ admin only | - |
| `/api/v1/users` | ✅ admin only | - | - | - |
| `/api/v1/me` | ✅ | - | - | - |
| `/api/v1/token` | - | ✅ no token required | - | - |

## Changes

- Add `api_token` column to users table
- Add `lib/lokka/app/api.rb` for API endpoints
- Add token generation and token authentication helpers to `User`
- Load API routes before catch-all entry routes
- Add minitest coverage for the API

## Tests

```text
22 runs, 52 assertions, 0 failures, 0 errors, 0 skips
```
